### PR TITLE
Fix Calculator Buttons on mobile

### DIFF
--- a/src/Components/Calculator/Calculator.jsx
+++ b/src/Components/Calculator/Calculator.jsx
@@ -170,6 +170,7 @@ export default function Calculator(props) {
                       <Fab
                         style={{ marginRight: 20 }}
                         onClick={() => addNumberSign()}
+                        onTouchStart={() => addNumberSign()}
                         size="small"
                         color="primary"
                         aria-label="add"

--- a/src/Components/Calculator/CalculatorButton.jsx
+++ b/src/Components/Calculator/CalculatorButton.jsx
@@ -34,6 +34,8 @@ export default function CalculatorButton(props) {
       <Button
         id={name}
         onClick={() => props.cb(props.val)}
+        // https://github.com/react-grid-layout/react-draggable/issues/550
+        onTouchStart={() => props.cb(props.val)}
         style={{
           width: 45,
           height: 45,


### PR DESCRIPTION
According to this [issue](https://github.com/react-grid-layout/react-draggable/issues/550) in `react-draggable`, there seems to be a difference in `MouseEvents` vs `TouchEvents` and how the draggable handles this.  

On mobile, buttons use a `touchstart` event where `preventDefault()` gets called which prevents the buttons being clicked.

Added a `onTouchStart` function to the buttons to resolve this, might need to revisit in the future.

Fixes #75 