### PR TITLE
Make history (Working out) easier to see on page

### DIFF
--- a/src/Components/WorkingOut/WorkingOut.jsx
+++ b/src/Components/WorkingOut/WorkingOut.jsx
@@ -5,16 +5,17 @@ import { useRef } from 'react';
 import { useEffect } from 'react';
 import { List } from '@mui/material';
 
+// 432 = 1.2 * 360
 const useStyles = makeStyles((theme) => ({
   root: {
     width: '100%',
-    maxWidth: 360,
+    maxWidth: 432,
     backgroundColor: theme.palette.background.paper,
     position: 'relative',
     bottom: 0,
     overflow: 'auto',
-    maxHeight: 150,
-    minHeight: 150,
+    maxHeight: 250,
+    minHeight: 250,
     overflowY: 'scroll',
   },
   listSection: {
@@ -23,6 +24,17 @@ const useStyles = makeStyles((theme) => ({
   ul: {
     backgroundColor: 'inherit',
     padding: 0,
+  },
+  '&::-webkit-scrollbar': {
+    '-webkit-appearance': 'none',
+    width: '7px',
+    height: '7px',
+    '-webkit-overflow-scrolling': 'auto',
+  },
+  '&::-webkit-scrollbar-thumb': {
+    borderRadius: '4px',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    '-webkit-box-shadow': '0 0 1px rgba(255, 255, 255, 0.5)',
   },
 }));
 

--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -31,3 +31,15 @@
     transform: rotate(360deg);
   }
 }
+
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 7px;
+  height: 7px;
+  -webkit-overflow-scrolling: auto;
+}
+::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+}


### PR DESCRIPTION
- Made the width and height of the working out larger so more history can be seen
- Tried to use [scrolling css](https://simurai.com/blog/2011/07/26/webkit-scrollbar) to show scroll bar on iPads (seems like all apple devices on show scroll bars when the user is scrolling otherwise this is hidden)
fixes #81 